### PR TITLE
Upgrade libraries: io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,14 +21,14 @@ lazy val api = project
       ws,
       guice,
       jdbc,
-      "io.flow" %% "lib-postgresql-play-play26" % "0.2.73",
-      "io.flow" %% "lib-play-graphite-play26" % "0.0.62",
+      "io.flow" %% "lib-postgresql-play-play26" % "0.2.74",
+      "io.flow" %% "lib-play-graphite-play26" % "0.0.63",
       "com.typesafe.play" %% "play-json-joda" % "2.6.10",
       "org.postgresql" % "postgresql" % "42.2.5",
       "net.jcazevedo" %% "moultingyaml" % "0.4.0",
-      "io.flow" %% "lib-test-utils" % "0.0.22" % Test,
-      "io.flow" %% "lib-usage" % "0.0.51",
-      "io.flow" %% "lib-log" % "0.0.50"
+      "io.flow" %% "lib-test-utils" % "0.0.25" % Test,
+      "io.flow" %% "lib-usage" % "0.0.53",
+      "io.flow" %% "lib-log" % "0.0.51"
     )
   )
 


### PR DESCRIPTION
- io.flow
  - lib-log (0.0.50 => 0.0.51)
  - lib-play-graphite-play26 (0.0.62 => 0.0.63)
  - lib-postgresql-play-play26 (0.2.73 => 0.2.74)
  - lib-test-utils (0.0.22 => 0.0.25)
  - lib-usage (0.0.51 => 0.0.53)
