### PR TITLE
Change deployment to use canary rollout

### DIFF
--- a/deploy/registry/templates/deployment.yaml
+++ b/deploy/registry/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $fullName := include "deploy.fullname" . -}}
 {{- range $stage, $deployment := index .Values "deployments" }}
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
 metadata:
   name: {{ $fullName }}-{{ $stage }}
   labels:
@@ -96,5 +96,19 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+  strategy:
+    canary:
+  {{- with $deployment.steps }}
+      steps:
+{{ toYaml . | indent 8 }}
+  {{- end }}
+      canaryService: {{ $fullName }}-canary
+      stableService: {{ $fullName }}
+      trafficRouting:
+        istio:
+          virtualService:
+            name: {{ $fullName }}-live
+            routes:
+              - primary # At least one route is required
 ---
 {{- end -}}

--- a/deploy/registry/templates/istio.yaml
+++ b/deploy/registry/templates/istio.yaml
@@ -41,13 +41,13 @@ spec:
     - destination:
         host: {{ $fullName }}
         port:
-          number: 9000
+          number: {{ $.Values.service.port }}
         subset:  {{ $stage.deployment }}
       weight: 100
     - destination:
         host: {{ $fullName }}-canary
         port:
-          number: 9000
+          number: {{ $.Values.service.port }}
         subset:  {{ $stage.deployment }}
       weight: 0
 {{- end }}

--- a/deploy/registry/templates/istio.yaml
+++ b/deploy/registry/templates/istio.yaml
@@ -35,11 +35,21 @@ spec:
   gateways:
 {{ toYaml $service.gateways | indent 4 }}
   http:
-  - route:
+  - name: primary
+    route:
 {{- range $stage := $service.stages }}
     - destination:
         host: {{ $fullName }}
+        port:
+          number: 9000
         subset:  {{ $stage.deployment }}
+      weight: 100
+    - destination:
+        host: {{ $fullName }}-canary
+        port:
+          number: 9000
+        subset:  {{ $stage.deployment }}
+      weight: 0
 {{- end }}
 ---
 {{- end -}}

--- a/deploy/registry/templates/service.yaml
+++ b/deploy/registry/templates/service.yaml
@@ -8,6 +8,27 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/name: {{ include "deploy.name" $ }}
+    app.kubernetes.io/stage: stable
+spec:
+  ports:
+    - port: {{ $.Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "deploy.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-canary
+  labels:
+    helm.sh/chart: {{ include "deploy.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/name: {{ include "deploy.name" $ }}
+    app.kubernetes.io/stage: canary
 spec:
   ports:
     - port: {{ $.Values.service.port }}

--- a/deploy/registry/templates/service.yaml
+++ b/deploy/registry/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/name: {{ include "deploy.name" $ }}
-    app.kubernetes.io/stage: stable
+    app.kubernetes.io/stage: live
 spec:
   ports:
     - port: {{ $.Values.service.port }}

--- a/deploy/registry/values.yaml
+++ b/deploy/registry/values.yaml
@@ -56,3 +56,10 @@ deployments:
     disruptionBudgetEnabled: true
     targetCPUUtilizationPercentage: 80
     version: #from commandline
+    steps:
+      - setWeight: 5
+      - pause:
+          duration: 60
+      - setWeight: 50
+      - pause:
+          duration: 60


### PR DESCRIPTION
Discussed at backend guild - idea is to convert a non critical service to using canary deployment (promotion strategy simple time delay).  Part of initiative to identify LOE to rollout (pardon the pun) to all other services.

@nemo83 Did you mention a preference for remove the use of "live"?  If so, this is a good place for us to practice.