### PR TITLE
Fdtn 1017 latest generic chart

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 properties([pipelineTriggers([githubPush()])])
 
+def chartname = "flow-generic"
+def chartversion = "^1.0.0"
+
 pipeline {
   options {
     disableConcurrentBuilds()
@@ -68,7 +71,7 @@ pipeline {
           steps {
             script {
               container('helm') {
-                new helmCommonDeploy().deploy('registry', 'production', VERSION.printable())
+                new helmGenericDeploy().deploy('registry', 'production', VERSION.printable(), "${chartname}", "${chartversion}")
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
       inheritFrom 'default'
 
       containerTemplates([
-        containerTemplate(name: 'helm', image: "lachlanevenson/k8s-helm:v2.12.0", command: 'cat', ttyEnabled: true),
+        containerTemplate(name: 'helm', image: "lachlanevenson/k8s-helm:v2.17.0", command: 'cat', ttyEnabled: true),
         containerTemplate(name: 'docker', image: 'docker:18', resourceRequestCpu: '1', resourceRequestMemory: '2Gi', command: 'cat', ttyEnabled: true)
       ])
     }

--- a/deploy/registry/requirements.yaml
+++ b/deploy/registry/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: flow-generic
-    version: 1.3.5
-    repository: https://flow.jfrog.io/artifactory/api/helm/generic-charts-helm

--- a/deploy/registry/requirements.yaml
+++ b/deploy/registry/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
-  - name: flow-generic-scala
-    version: 1.2.3
+  - name: flow-generic
+    version: 1.3.5
     repository: https://flow.jfrog.io/artifactory/api/helm/generic-charts-helm

--- a/deploy/registry/values.yaml
+++ b/deploy/registry/values.yaml
@@ -1,14 +1,13 @@
 nameOverride: "registry"
 fullnameOverride: "registry"
 
-service:
-  port: 9000
-
+team: "foundation"
 
 iamRole: arn:aws:iam::479720515435:role/ecsInstanceRole
+
 image:
   repository: flowcommerce/registry
-  pullPolicy: IfNotPresent
+
 resources:
   limits:
     memory: "900Mi"
@@ -18,86 +17,31 @@ resources:
     cpu: .05
 
 jvmOpts:
-  memory: 500m
-  extraArgs: "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt -XX:+UseG1GC -XX:+UseStringDeduplication"
-
-nodeSelector: {} 
-
-
-tolerations: {} 
-
-ingress:
-  enabled: true
-  gateways:
-    - key: registry-flow-io
-      tld: api.flow.io
-      dns: true
-      hosts:
-        - registry.api.flow.io
-    - key: registry-flow-pub
-      tld: flo.pub
-      dns: true
-      hosts:
-        - registry.flo.pub
-
-services:
-  live:
-    hosts:
-      - registry
-      - registry.api.flow.io
-      - registry.flo.pub
-    gateways:
-      - mesh
-      - registry-flow-io
-      - registry-flow-pub
-    stages:
-      - deployment: live
-        weight: 100
-
-istio:
-  terminationDrainDuration: 30s
+   memory: 500m
 
 deployments:
   live:
     minReplicas: 2
     maxReplicas: 2
     maxUnavailable: 1
-    disruptionBudgetEnabled: true
-    targetCPUUtilizationPercentage: 80
-    version: #from commandline
-    strategy: RollingUpdate
-    maxSurge: 10%
+
+rolloutResource:
+   enabled: true 
 
 canary: 
   enabled: true # Disable this to follow the default RollingUpdate Strategy
   migration: false
-  steps:
-    - setWeight: 15
-    - pause:
-        duration: 60
-    - setWeight: 30
-    - pause:
-        duration: 60
-    - setWeight: 60
-    - pause:
-        duration: 60
   analysis:
    - name: error-rate
-     interval: 30s
      successCondition: default(result, 0) < 0.05   
-     failureLimit: 0
      provider:
       datadog:
-        interval: 30s
         query: |
           sum:trace.akka_http.request.errors{service:registry}.as_count()  /
           sum:trace.akka_http.request.hits{service:registry}.as_count()
    - name: response-time
-     interval: 30s
      successCondition: default(result, 0) < 0.1
-     failureLimit: 0
      provider:
       datadog:
-        interval: 30s
         query: p95:trace.akka_http.request{service:registry}
         


### PR DESCRIPTION
```diff
production, registry, Service (v1) has changed:
- # Source: flow-generic-scala/templates/service.yaml
+ # Source: flow-generic/templates/service.yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: registry
    labels:
-     helm.sh/chart: flow-generic-scala-1.2.3
+     helm.sh/chart: flow-generic-1.3.5
      app.kubernetes.io/instance: registry
      app.kubernetes.io/managed-by: Tiller
      app.kubernetes.io/name: registry
      app: registry
  spec:
    ports:
      - port: 80
        targetPort: http
        protocol: TCP
        name: http
    selector:
      app.kubernetes.io/name: registry
      app.kubernetes.io/instance: registry
production, registry-flow-io, Gateway (networking.istio.io) has changed:
- # Source: flow-generic-scala/templates/ingress.yaml
+ # Source: flow-generic/templates/ingress-defaults.yaml
  apiVersion: networking.istio.io/v1alpha3
  kind: Gateway
  metadata:
    name: registry-flow-io
    labels:
      app.kubernetes.io/name: registry
-     helm.sh/chart: flow-generic-scala-1.2.3
+     helm.sh/chart: flow-generic-1.3.5
      app.kubernetes.io/instance: registry
      app.kubernetes.io/managed-by: Tiller
      app: registry
    annotations:
      kubernetes.io/ingress.class: "ingressgateway"
      kubernetes.io/ingress.tld: "api.flow.io"
      external-dns.alpha.kubernetes.io/ttl: "120"
  spec:
    selector:
      istio: ingressgateway
    servers:
      - port:
          number: 80
          name: http
          protocol: HTTP2
        hosts:
-         - "registry.api.flow.io"
+         - registry.api.flow.io
        tls:
          httpsRedirect: true
      - port:
          number: 443
          name: https
          protocol: HTTP2
        hosts:
-         - "registry.api.flow.io"
+         - registry.api.flow.io
production, registry-flow-pub, Gateway (networking.istio.io) has changed:
- # Source: flow-generic-scala/templates/ingress.yaml
+ # Source: flow-generic/templates/ingress-defaults.yaml
  apiVersion: networking.istio.io/v1alpha3
  kind: Gateway
  metadata:
    name: registry-flow-pub
    labels:
      app.kubernetes.io/name: registry
-     helm.sh/chart: flow-generic-scala-1.2.3
+     helm.sh/chart: flow-generic-1.3.5
      app.kubernetes.io/instance: registry
      app.kubernetes.io/managed-by: Tiller
      app: registry
    annotations:
      kubernetes.io/ingress.class: "ingressgateway"
      kubernetes.io/ingress.tld: "flo.pub"
      external-dns.alpha.kubernetes.io/ttl: "120"
  spec:
    selector:
      istio: ingressgateway
    servers:
      - port:
          number: 80
          name: http
          protocol: HTTP2
        hosts:
-         - "registry.flo.pub"
+         - registry.flo.pub
        tls:
          httpsRedirect: true
      - port:
          number: 443
          name: https
          protocol: HTTP2
        hosts:
-         - "registry.flo.pub"
+         - registry.flo.pub
production, registry-live, Deployment (apps) has changed:
- # Source: flow-generic-scala/templates/deployment.yaml
+ # Source: flow-generic/templates/deployment.yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: registry-live
    labels:
-     helm.sh/chart: flow-generic-scala-1.2.3
+     helm.sh/chart: flow-generic-1.3.5
      app.kubernetes.io/instance: registry
      app.kubernetes.io/managed-by: Tiller
      app.kubernetes.io/name: registry
      app: registry
      app.kubernetes.io/stage: live
      flow.io/version: 0.6.53
      flow.io/team: foundation
  spec:
    replicas: 0
    selector:
      matchLabels:
        app.kubernetes.io/name: registry
        app.kubernetes.io/instance: registry
        app.kubernetes.io/stage: live
    template:
      metadata:
        labels:
          app.kubernetes.io/name: registry
          app.kubernetes.io/instance: registry
          app.kubernetes.io/stage: live
          app: registry
          flow.io/version: 0.6.53
          flow.io/team: foundation
        annotations:
          iam.amazonaws.com/role: arn:aws:iam::479720515435:role/ecsInstanceRole
          sumologic.com/sourceCategory: registry
          sidecar.istio.io/logLevel: info
          proxy.istio.io/config: '{"terminationDrainDuration": 30s}'
      spec:
        terminationGracePeriodSeconds: 60
        containers:
          - name: registry
            image: "flowcommerce/registry:0.6.53"
            imagePullPolicy: IfNotPresent
            env:
              - name: JAVA_OPTS
-               value: "-Xms500m -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt -XX:+UseG1GC -XX:+UseStringDeduplication"              
+               value: "-Xms500m -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt -XX:+UseG1GC -XX:+UseStringDeduplication"
              - name: FLOW_KUBERNETES_NODE_NAME
                valueFrom:
                  fieldRef:
                    fieldPath: spec.nodeName
              - name: FLOW_KUBERNETES_NODE_IP
                valueFrom:
                  fieldRef:
                    fieldPath: status.hostIP
              - name: FLOW_KUBERNETES_POD_NAME
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.name
              - name: FLOW_KUBERNETES_POD_NAMESPACE
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.namespace
              - name: FLOW_KUBERNETES_POD_IP
                valueFrom:
                  fieldRef:
                    fieldPath: status.podIP
              - name: FLOW_KUBERNETES_POD_UID
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.uid
              - name: DD_SERVICE
                value: registry
              - name: DD_ENV
                value: live
              - name: DD_VERSION
                value: 0.6.53
              - name: DD_JMXFETCH_STATSD_HOST
                value: 'unix:///var/run/datadog/dsd.socket'
              - name: DD_SERVICE_MAPPING
                value: postgresql:registry-postgresql,java-aws-sdk:registry-aws-sdk"
            args: ["production"]
            ports:
              - name: http
                containerPort: 9000
                protocol: TCP
            volumeMounts:
              - name: dsdsocket
                mountPath: /var/run/datadog
            startupProbe:
              httpGet:
                path: /_internal_/healthcheck
                port: http
              failureThreshold: 30
              periodSeconds: 10
            livenessProbe:
              httpGet:
                path: /_internal_/healthcheck
                port: http
              failureThreshold: 6
              periodSeconds: 10
              timeoutSeconds: 5
            readinessProbe:
              httpGet:
                path: /_internal_/healthcheck
                port: http
              failureThreshold: 3
              periodSeconds: 10
              timeoutSeconds: 5
            resources:
              limits:
                cpu: 1
                memory: 900Mi
              requests:
                cpu: 0.05
                memory: 900Mi
              
        imagePullSecrets:
          - name: flow-docker-hub
        affinity:
          podAntiAffinity:
            preferredDuringSchedulingIgnoredDuringExecution:
            - weight: 100
              podAffinityTerm:
                labelSelector:
                  matchExpressions:
                  - key: app
                    operator: In
                    values:
                    - registry
                topologyKey: topology.kubernetes.io/zone
        dnsConfig:
          options:
            - name: ndots
              value: "1"
        volumes:
          - name: dsdsocket
            hostPath:
              path: /var/run/datadog/
              type: DirectoryOrCreate
    strategy:
      type: RollingUpdate
production, registry-live, DestinationRule (networking.istio.io) has been removed:
- # Source: flow-generic-scala/templates/istio.yaml
- apiVersion: networking.istio.io/v1alpha3
- kind: DestinationRule
- metadata:
-   name: registry-live
- spec:
-   host: registry
-   trafficPolicy:
-     tls:
-       mode: ISTIO_MUTUAL
-     loadBalancer:
-       simple: ROUND_ROBIN
-   subsets:
-     - name: live
-       labels:
-         app: registry
-     - name: canary
-       labels:
-         app: registry
+ 
production, registry-live, PodDisruptionBudget (policy) has changed:
- # Source: flow-generic-scala/templates/disruption.yaml
+ # Source: flow-generic/templates/disruption.yaml
  apiVersion: policy/v1beta1
  kind: PodDisruptionBudget
  metadata:
    name: registry-live
  spec:
    maxUnavailable: 1
    selector:
      matchLabels:
        app.kubernetes.io/instance: registry
        app.kubernetes.io/stage: live
production, registry-live, Rollout (argoproj.io) has changed:
- # Source: flow-generic-scala/templates/rollout.yaml
+ # Source: flow-generic/templates/rollout.yaml
  apiVersion: argoproj.io/v1alpha1
  kind: Rollout
  metadata:
    name: registry-live
    annotations:
      notifications.argoproj.io/subscribe.on-rollout-completed.slack: deploys
      notifications.argoproj.io/subscribe.on-rollout-aborted.slack: deploys
      notifications.argoproj.io/subscribe.on-analysis-run-failed.slack: deploys
-     
+ 
  spec:
    replicas: 2
     # Reference an existing Deployment using workloadRef field
    workloadRef:
      apiVersion: apps/v1
      kind: Deployment
      name: registry-live
    strategy:
      canary:
        maxSurge: 10%
-       maxUnavailable: 1 
+       maxUnavailable: 1
         # If the steps field is omitted, the canary strategy will mimic the rolling update behavior
-       steps:                    
+       steps:
              - setWeight: 15
              - pause:
                  duration: 60
              - setWeight: 30
              - pause:
                  duration: 60
              - setWeight: 60
              - pause:
                  duration: 60
              
        analysis:
          templates:
          - templateName: registry-rollout-analysis
          # This is to begin the analysis from the specified step.
          startingStep: 1
        # dynamically scale the stable/live ReplicaSet according to traffic weight
-       dynamicStableScale: false  
+       dynamicStableScale: false
        trafficRouting:
          istio:
            destinationRule:
              canarySubsetName: canary
-             name: registry-live
+             name: registry-rollout-live
              stableSubsetName: live
            virtualService:
-             name: registry-live
+             name: registry-rollout-live
              routes:
              - primary
  
    revisionHistoryLimit: 5
    progressDeadlineSeconds: 900
  
    # Whether to abort the update when ProgressDeadlineSeconds
    # is exceeded if analysis or experiment is not used.
    # Optional and default is false.
    progressDeadlineAbort: true
production, registry-live, VirtualService (networking.istio.io) has been removed:
- # Source: flow-generic-scala/templates/istio.yaml
- apiVersion: networking.istio.io/v1alpha3
- kind: VirtualService
- metadata:
-   name: registry-live
-   labels:
-     app.kubernetes.io/name: registry
-     helm.sh/chart: flow-generic-scala-1.2.3
-     app.kubernetes.io/instance: registry
-     app.kubernetes.io/managed-by: Tiller
-     app: registry
- spec:
-   hosts:
-     - registry
-     - registry.api.flow.io
-     - registry.flo.pub
-     
-   gateways:
-     - mesh
-     - registry-flow-io
-     - registry-flow-pub
-     
-   http:
-   - name: primary
-     route:
-     - destination:
-         host: registry
-         port:
-           number: 80
-         subset:  live
-       weight: 100
-     - destination:
-         host: registry
-         port:
-           number: 80
-         subset: canary
-       weight: 0
+ 
production, registry-rollout-analysis, AnalysisTemplate (argoproj.io) has changed:
- # Source: flow-generic-scala/templates/analysis.yaml
+ # Source: flow-generic/templates/analysis.yaml
  apiVersion: argoproj.io/v1alpha1
  kind: AnalysisTemplate
  metadata:
    name: registry-rollout-analysis
  spec:
    metrics:
-       - failureLimit: 0
-         interval: 30s
-         name: error-rate
-         provider:
-           datadog:
-             interval: 30s
-             query: |
-               sum:trace.akka_http.request.errors{service:registry}.as_count()  /
-               sum:trace.akka_http.request.hits{service:registry}.as_count()
-         successCondition: default(result, 0) < 0.05
-       - failureLimit: 0
-         interval: 30s
-         name: response-time
-         provider:
-           datadog:
-             interval: 30s
-             query: p95:trace.akka_http.request{service:registry}
-         successCondition: default(result, 0) < 0.1
+   - name: error-rate
+     interval: 30s
+     successCondition: default(result, 0) < 0.05
+     failureLimit: 0
+     provider:
+       datadog:
+         interval:           30s
+         query:           sum:trace.akka_http.request.errors{service:registry}.as_count()  /
+           sum:trace.akka_http.request.hits{service:registry}.as_count()
+           
+   - name: response-time
+     interval: 30s
+     successCondition: default(result, 0) < 0.1
+     failureLimit: 0
+     provider:
+       datadog:
+         interval:           30s
+         query:           p95:trace.akka_http.request{service:registry}
production, registry-rollout-live, DestinationRule (networking.istio.io) has been added:
- 
+ # Source: flow-generic/templates/istio-rollout.yaml
+ apiVersion: networking.istio.io/v1alpha3
+ kind: DestinationRule
+ metadata:
+   name: registry-rollout-live
+ spec:
+   host: registry
+   trafficPolicy:
+     tls:
+       mode: ISTIO_MUTUAL
+     loadBalancer:
+       simple: ROUND_ROBIN
+   subsets:
+     - name: live
+       labels:
+         app: registry
+     - name: canary
+       labels:
+         app: registry
production, registry-rollout-live, VirtualService (networking.istio.io) has been added:
- 
+ # Source: flow-generic/templates/istio-rollout.yaml
+ apiVersion: networking.istio.io/v1alpha3
+ kind: VirtualService
+ metadata:
+   name: registry-rollout-live
+   labels:
+     app.kubernetes.io/name: registry
+     helm.sh/chart: flow-generic-1.3.5
+     app.kubernetes.io/instance: registry
+     app.kubernetes.io/managed-by: Tiller
+     app: registry
+ spec:
+   hosts:
+     - registry
+     - registry.api.flow.io
+     - registry.flo.pub
+   gateways:
+     - mesh
+     - registry-flow-io
+     - registry-flow-pub
+   http:
+   - name: primary
+     route:
+     - destination:
+         host: registry
+         port:
+           number: 80
+         subset:  live
+       weight: 100
+     - destination:
+         host: registry
+         port:
+           number: 80
+         subset: canary
+       weight: 0
+     retries:
+       attempts: 3
+       perTryTimeout: 2s
+       retryOn: connect-failure,refused-stream,503


```