### PR TITLE
Upgrade libraries io.flow, org.postgresql

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,14 +27,14 @@ lazy val api = project
       ws,
       guice,
       jdbc,
-      "io.flow" %% "lib-postgresql-play-play28" % "0.4.60",
-      "io.flow" %% "lib-metrics-play28" % "1.0.29",
+      "io.flow" %% "lib-postgresql-play-play28" % "0.4.62",
+      "io.flow" %% "lib-metrics-play28" % "1.0.31",
       "com.typesafe.play" %% "play-json-joda" % "2.9.2",
-      "org.postgresql" % "postgresql" % "42.3.6",
+      "org.postgresql" % "postgresql" % "42.4.0",
       "net.jcazevedo" %% "moultingyaml" % "0.4.2",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.75" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.1.91",
-      "io.flow" %% "lib-log" % "0.1.68"
+      "io.flow" %% "lib-test-utils-play28" % "0.1.77" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.1.94",
+      "io.flow" %% "lib-log" % "0.1.70"
     ),
     scalacOptions ++= allScalacOptions,
   )


### PR DESCRIPTION
- io.flow
  - lib-log (0.1.68 => 0.1.70)
  - lib-metrics-play28 (1.0.29 => 1.0.31)
  - lib-postgresql-play-play28 (0.4.60 => 0.4.62)
  - lib-test-utils-play28 (0.1.75 => 0.1.77)
  - lib-usage-play28 (0.1.91 => 0.1.94)
- org.postgresql
  - postgresql (42.3.6 => 42.4.0)