### PR TITLE
Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,19 +22,19 @@ lazy val api = project
   .settings(
     routesImport += "io.flow.registry.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.2.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.3.0",
     libraryDependencies ++= Seq(
       ws,
       guice,
       jdbc,
-      "io.flow" %% "lib-postgresql-play-play28" % "0.4.83",
-      "io.flow" %% "lib-metrics-play28" % "1.0.41",
+      "io.flow" %% "lib-postgresql-play-play28" % "0.4.89",
+      "io.flow" %% "lib-metrics-play28" % "1.0.45",
       "com.typesafe.play" %% "play-json-joda" % "2.9.3",
       "org.postgresql" % "postgresql" % "42.5.1",
       "net.jcazevedo" %% "moultingyaml" % "0.4.2",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.86" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.5",
-      "io.flow" %% "lib-log" % "0.1.80"
+      "io.flow" %% "lib-test-utils-play28" % "0.1.90" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.7",
+      "io.flow" %% "lib-log" % "0.1.83"
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -42,7 +42,7 @@ lazy val api = project
 lazy val commonSettings: Seq[Setting[_]] = Seq(
   name ~= ("registry-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-healthcheck-play28" % "0.0.2",
+    "io.flow" %% "lib-healthcheck-play28" % "0.0.4",
     specs2 % Test
   ),
   Compile / doc / sources := Seq.empty,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.34")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.35")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.2.0 => 1.3.0)
- io.flow
  - lib-healthcheck-play28 (0.0.2 => 0.0.4)
  - lib-log (0.1.80 => 0.1.83)
  - lib-metrics-play28 (1.0.41 => 1.0.45)
  - lib-postgresql-play-play28 (0.4.83 => 0.4.89)
  - lib-test-utils-play28 (0.1.86 => 0.1.90)
  - lib-usage-play28 (0.2.5 => 0.2.7)
  - sbt-flow-linter (0.0.34 => 0.0.35)