### PR TITLE
FIN-1538: Update trueup related API Builder specs

### DIFF
--- a/.apibuilder/.tracked_files
+++ b/.apibuilder/.tracked_files
@@ -3,7 +3,6 @@ flow:
   common:
     anorm_2_8_parsers:
     - api/app/generated/FlowCommonV0Conversions.scala
-    - api/app/generated/FlowCommonV0Parsers.scala
     play_2_x_json:
     - api/app/generated/FlowCommonV0Models.scala
   error:
@@ -17,7 +16,6 @@ flow:
   registry:
     anorm_2_8_parsers:
     - api/app/generated/FlowRegistryV0Conversions.scala
-    - api/app/generated/FlowRegistryV0Parsers.scala
     play_2_8_client:
     - api/app/generated/FlowRegistryV0Client.scala
     play_2_x_routes:


### PR DESCRIPTION
We moved shared trueup models to the public trueup.json spec. Note we also standardized on trueup as a single word. No functional change - just renaming