### PR TITLE
FDN-2397:upgrade-scala-v2.13.13-sbt-version-upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "registry"
 
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.13.13"
 ThisBuild / javacOptions ++= Seq("-source", "17", "-target", "17")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0


### PR DESCRIPTION
In this PR we are upgrading scala version from v2.13.10 to v2.13.13 and sbt version from v1.9.9 to v1.10.0
