### PR TITLE
FDN-2872 registry service migration to Karpenter

### DIFF
--- a/deploy/registry/values.yaml
+++ b/deploy/registry/values.yaml
@@ -15,9 +15,9 @@ image:
 
 resources:
   limits:
-    memory: "900Mi"
+    memory: "1000Mi"
   requests:
-    memory: "900Mi"
+    memory: "1000Mi"
     cpu: .05
 
 jvmOpts:
@@ -29,14 +29,12 @@ deployments:
     maxReplicas: 2
     maxUnavailable: 1
 
-# Migrate registry service to arm64 platform
 nodeSelector:
-  role: workers-arm64
-
-tolerations: 
+  karpenter/role: workers
+tolerations:
   - key: "role"
     operator: "Equal"
-    value: "workers-arm64"
+    value: "workers"
     effect: "NoSchedule"
 
 rollout: 


### PR DESCRIPTION
two changes : 
- adding node selector and tolerations to migrate service to Karpenter
- bump memory request because we are running on a edge

![Screenshot 2024-10-04 at 10 20 20 AM](https://github.com/user-attachments/assets/72f97019-a02d-4f76-82dd-f533949dff2f)
