### PR TITLE
FDN-3307 Wind back one version of postgresql driver lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val api = project
       "io.flow" %% "lib-postgresql-play-play29" % "0.5.88",
       "io.flow" %% "lib-metrics-play29" % "1.1.6",
       "com.typesafe.play" %% "play-json-joda" % "2.10.6",
-      "org.postgresql" % "postgresql" % "42.7.5",
+      "org.postgresql" % "postgresql" % "42.7.4",
       "net.jcazevedo" %% "moultingyaml" % "0.4.2",
       "io.flow" %% "lib-test-utils-play29" % "0.2.45" % Test,
       "io.flow" %% "lib-usage-play29" % "0.2.67",


### PR DESCRIPTION

Due to an issue [[here](https://github.com/pgjdbc/pgjdbc/issues/3508)] with version 42.7.5 of the postgresql driver lib, we need to revert back to 42.7.4.

The issue is that the `ApplicationName` parameter on the db url gets lost when `assumeMinServerVersion` is set.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>